### PR TITLE
Add Python executable option to cmake build configuration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ class cmake_ext(build_ext):
 
         cmake_options = [
             f"-DCMAKE_INSTALL_PREFIX={install_dir}",
+            f"-DPython_EXECUTABLE={sys.executable}",
         ]
 
         CUDA_HOME = os.environ.get("CUDA_HOME")


### PR DESCRIPTION
It is sometimes very helpful when python preset for cmake builder was not set. 